### PR TITLE
export VAULT_ADDR

### DIFF
--- a/cluster-init.sh
+++ b/cluster-init.sh
@@ -2,6 +2,7 @@
 
 TEMP_DIR=".temp"
 mkdir -p $TEMP_DIR
+export VAULT_ADDR='http://127.0.0.1:8200'
 
 if [ ! -f $TEMP_DIR/vault-init.json ]; then
      vault operator init --format json -n 1 -t 1 > $TEMP_DIR/vault-init.json


### PR DESCRIPTION
I may be wrong but I think we need to export the VAULT_ADDR, otherwise we won't configure vault engine properly for the config we want.

I tried doing something like 

```
export VAULT_ADDR==$(echo "http://"$(cat ./config/vault.json | jq -r ".listener.tcp.address"))
```

to grab onto the same listener addr as the config but that didn't seem to produce a valid url 🤔